### PR TITLE
Use existing tool for polygon news

### DIFF
--- a/tradingagents/agents/analysts/news_analyst.py
+++ b/tradingagents/agents/analysts/news_analyst.py
@@ -17,8 +17,7 @@ def create_news_analyst(llm, toolkit, polygon_toolkit, config=None):
         if toolkit.config["online_tools"]:
             tools = [
                 toolkit.get_global_news_openai, 
-                toolkit.get_google_news, 
-                polygon_toolkit.get_polygon_news]
+                toolkit.get_google_news]
         else:
             tools = [
                 toolkit.get_finnhub_news,


### PR DESCRIPTION
Remove `polygon_toolkit.get_polygon_news` from news analyst tools because the method does not exist.

The `PolygonToolkit` does not provide a `get_polygon_news` method, leading to an `AttributeError`. This change ensures the news analyst uses existing, functional news tools.

---
<a href="https://cursor.com/background-agent?bcId=bc-89a9130b-719f-4593-a950-f68057f64bf2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-89a9130b-719f-4593-a950-f68057f64bf2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

